### PR TITLE
feat/postRepository-mysql

### DIFF
--- a/core/src/main/kotlin/com/meansoup/whatisthebetter/application/port/out/post/PostRepositoryImpl.kt
+++ b/core/src/main/kotlin/com/meansoup/whatisthebetter/application/port/out/post/PostRepositoryImpl.kt
@@ -1,18 +1,30 @@
 package com.meansoup.whatisthebetter.application.port.out.post
 
+import com.meansoup.whatisthebetter.application.port.out.post.mysql.MysqlPostFactory
+import com.meansoup.whatisthebetter.application.port.out.post.mysql.MysqlPostJpaRepository
+import com.meansoup.whatisthebetter.domain.exception.ResourceNotExistException
 import com.meansoup.whatisthebetter.domain.post.Post
 import com.meansoup.whatisthebetter.domain.post.PostRepository
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Repository
 import java.util.*
 
 @Repository
-class PostRepositoryImpl: PostRepository {
+class PostRepositoryImpl @Autowired constructor(
+    private val mysqlPostJpaRepository: MysqlPostJpaRepository
+): PostRepository {
 
     override fun save(post: Post) {
-        TODO("Not yet implemented")
+        val mysqlPost = MysqlPostFactory.create(post)
+        mysqlPostJpaRepository.save(mysqlPost)
     }
 
     override fun findBy(id: UUID): Post {
-        TODO("Not yet implemented")
+        val found = mysqlPostJpaRepository.findByIdOrNull(id.toString())
+
+        found?: throw ResourceNotExistException("Post not exist: $id")
+
+        return MysqlPostFactory.create(found)
     }
 }

--- a/core/src/main/kotlin/com/meansoup/whatisthebetter/application/port/out/post/mysql/MysqlPost.kt
+++ b/core/src/main/kotlin/com/meansoup/whatisthebetter/application/port/out/post/mysql/MysqlPost.kt
@@ -1,0 +1,39 @@
+package com.meansoup.whatisthebetter.application.port.out.post.mysql
+
+import javax.persistence.Entity
+import javax.persistence.Table
+
+@Entity
+@Table(name = "post")
+class MysqlPost {
+
+    var id: String? = null
+
+    var userId: String? = null
+
+    var title: String? = null
+
+    var content1Title: String? = null
+    var content1Description: String? = null
+
+    var content2Title: String? = null
+    var content2Description: String? = null
+
+    var createdAt: Long? = null
+    var modifiedAt: Long? = null
+
+    constructor(
+        id: String?, owner: String?, title: String?, content1Title: String?, content1Description: String?,
+        content2Title: String?, content2Description: String?, createdAt: Long?, modifiedAt: Long?
+    ) {
+        this.id = id
+        this.userId = owner
+        this.title = title
+        this.content1Title = content1Title
+        this.content1Description = content1Description
+        this.content2Title = content2Title
+        this.content2Description = content2Description
+        this.createdAt = createdAt
+        this.modifiedAt = modifiedAt
+    }
+}

--- a/core/src/main/kotlin/com/meansoup/whatisthebetter/application/port/out/post/mysql/MysqlPostFactory.kt
+++ b/core/src/main/kotlin/com/meansoup/whatisthebetter/application/port/out/post/mysql/MysqlPostFactory.kt
@@ -1,0 +1,49 @@
+package com.meansoup.whatisthebetter.application.port.out.post.mysql
+
+import com.meansoup.whatisthebetter.domain.exception.NullPropertyException
+import com.meansoup.whatisthebetter.domain.post.Content
+import com.meansoup.whatisthebetter.domain.post.Post
+import com.meansoup.whatisthebetter.domain.post.Title
+import java.util.*
+
+class MysqlPostFactory {
+
+    companion object {
+        fun create(post: Post): MysqlPost {
+            return MysqlPost(
+                post.id.toString(),
+                post.userId.toString(),
+                post.title.name,
+                post.content1.title,
+                post.content1.description,
+                post.content2.title,
+                post.content2.description,
+                post.createdAt,
+                post.modifiedAt
+            )
+        }
+
+        fun create(mysqlPost: MysqlPost): Post {
+            val title = mysqlPost.title ?: throw NullPropertyException("title is null in: " + mysqlPost.id)
+
+            val content1Title = mysqlPost.content1Title ?: throw NullPropertyException("content1Title is null in: " + mysqlPost.id)
+            val content1Description = mysqlPost.content1Description ?: throw NullPropertyException("content1Description is null in: " + mysqlPost.id)
+
+            val content2Title = mysqlPost.content2Title ?: throw NullPropertyException("content2Title is null in: " + mysqlPost.id)
+            val content2Description = mysqlPost.content2Description ?: throw NullPropertyException("content2Description is null in: " + mysqlPost.id)
+
+            val createdAt = mysqlPost.createdAt ?: throw NullPropertyException("createdAt is null in: " + mysqlPost.id)
+            val modifiedAt = mysqlPost.modifiedAt ?: throw NullPropertyException("modifiedAt is null in: " + mysqlPost.id)
+
+            return Post(
+                UUID.fromString(mysqlPost.id),
+                UUID.fromString(mysqlPost.userId),
+                Title(title),
+                Content(content1Title, content1Description),
+                Content(content2Title, content2Description),
+                createdAt,
+                modifiedAt
+            )
+        }
+    }
+}

--- a/core/src/main/kotlin/com/meansoup/whatisthebetter/application/port/out/post/mysql/MysqlPostJpaRepository.kt
+++ b/core/src/main/kotlin/com/meansoup/whatisthebetter/application/port/out/post/mysql/MysqlPostJpaRepository.kt
@@ -1,0 +1,7 @@
+package com.meansoup.whatisthebetter.application.port.out.post.mysql
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface MysqlPostJpaRepository : JpaRepository<MysqlPost, String>

--- a/core/src/main/kotlin/com/meansoup/whatisthebetter/application/post/CreatePostAppService.kt
+++ b/core/src/main/kotlin/com/meansoup/whatisthebetter/application/post/CreatePostAppService.kt
@@ -28,7 +28,7 @@ class CreatePostAppService @Autowired constructor(
         val user = userRepository.findBy(userUuid)
 
         val post = Post(
-            user,
+            user.id,
             Title(postTitle),
             Content(content1Title, content1Description),
             Content(content2Title, content2Description)

--- a/core/src/main/kotlin/com/meansoup/whatisthebetter/application/post/GetPostAppService.kt
+++ b/core/src/main/kotlin/com/meansoup/whatisthebetter/application/post/GetPostAppService.kt
@@ -35,7 +35,7 @@ class GetPostAppService @Autowired constructor(
 
         return GetPostDto(
             post.id.toString(),
-            post.owner.name.name,
+            post.userId.toString(),
             post.title.name,
             post.content1.title,
             post.content1.description,

--- a/core/src/main/kotlin/com/meansoup/whatisthebetter/domain/post/Post.kt
+++ b/core/src/main/kotlin/com/meansoup/whatisthebetter/domain/post/Post.kt
@@ -6,16 +6,16 @@ import java.util.*
 
 class Post: Likeable {
     val id: UUID
-    var owner: User
+    var userId: UUID
     var title: Title
     var content1: Content
     var content2: Content
     var createdAt: Long
     var modifiedAt: Long
 
-    constructor(owner: User, title: Title, content1: Content, content2: Content) {
+    constructor(userId: UUID, title: Title, content1: Content, content2: Content) {
         this.id = UUID.randomUUID()
-        this.owner = owner
+        this.userId = userId
         this.title = title
         this.content1 = content1
         this.content2 = content2

--- a/core/src/main/kotlin/com/meansoup/whatisthebetter/domain/post/Post.kt
+++ b/core/src/main/kotlin/com/meansoup/whatisthebetter/domain/post/Post.kt
@@ -1,7 +1,6 @@
 package com.meansoup.whatisthebetter.domain.post
 
 import com.meansoup.whatisthebetter.domain.like.Likeable
-import com.meansoup.whatisthebetter.domain.user.User
 import java.util.*
 
 class Post: Likeable {
@@ -23,5 +22,15 @@ class Post: Likeable {
         val currentTime = System.currentTimeMillis()
         this.createdAt = currentTime
         this.modifiedAt = currentTime
+    }
+
+    constructor(id: UUID, userId: UUID, title: Title, content1: Content, content2: Content, createdAt: Long, modifiedAt: Long) {
+        this.id = id
+        this.userId = userId
+        this.title = title
+        this.content1 = content1
+        this.content2 = content2
+        this.createdAt = createdAt
+        this.modifiedAt = modifiedAt
     }
 }

--- a/core/src/main/resources/post.sql
+++ b/core/src/main/resources/post.sql
@@ -1,0 +1,17 @@
+--CREATE DATABASE what;
+
+CREATE TABLE post(
+    id VARCHAR(128) NOT NULL,
+    user_id VARCHAR(128) NOT NULL,
+    title TEXT NOT NULL,
+
+    content1_title TEXT NOT NULL,
+    content1_description MEDIUMTEXT NOT NULL,
+
+    content2_title TEXT NOT NULL,
+    content2_description MEDIUMTEXT NOT NULL,
+
+    created_at BIGINT NOT NULL,
+    modified_at BIGINT NOT NULL,
+    primary key(id)
+);

--- a/core/src/test/kotlin/com/meansoup/whatisthebetter/application/port/out/post/PostRepositoryImplTest.kt
+++ b/core/src/test/kotlin/com/meansoup/whatisthebetter/application/port/out/post/PostRepositoryImplTest.kt
@@ -1,0 +1,98 @@
+package com.meansoup.whatisthebetter.application.port.out.post
+
+import com.meansoup.whatisthebetter.application.port.out.post.mysql.MysqlPost
+import com.meansoup.whatisthebetter.application.port.out.post.mysql.MysqlPostFactory
+import com.meansoup.whatisthebetter.application.port.out.post.mysql.MysqlPostJpaRepository
+import com.meansoup.whatisthebetter.domain.exception.ResourceNotExistException
+import com.meansoup.whatisthebetter.domain.post.PostMother
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.*
+import org.mockito.Mockito.*
+import org.mockito.junit.jupiter.MockitoExtension
+import java.util.*
+
+@ExtendWith(MockitoExtension::class)
+internal class PostRepositoryImplTest {
+
+    @Mock
+    lateinit var mysqlPostJpaRepository: MysqlPostJpaRepository
+
+    @InjectMocks
+    lateinit var sut: PostRepositoryImpl
+
+    @Captor
+    lateinit var captor: ArgumentCaptor<MysqlPost>
+
+    @Nested
+    inner class findBy {
+
+        @Test
+        fun normalCase() {
+            // given
+            val post = PostMother.generate()
+            val mysqlPost = MysqlPostFactory.create(post)
+
+            doReturn(Optional.of(mysqlPost)).`when`(mysqlPostJpaRepository).findById(safeEq(post.id.toString()))
+
+            // when
+            val found = sut.findBy(post.id)
+
+            // then
+            assertThat(found.id).isEqualTo(post.id)
+            assertThat(found.userId).isEqualTo(post.userId)
+            assertThat(found.title.name).isEqualTo(post.title.name)
+            assertThat(found.content1.title).isEqualTo(post.content1.title)
+            assertThat(found.content1.description).isEqualTo(post.content1.description)
+            assertThat(found.content2.title).isEqualTo(post.content2.title)
+            assertThat(found.content2.description).isEqualTo(post.content2.description)
+            assertThat(found.createdAt).isEqualTo(post.createdAt)
+            assertThat(found.modifiedAt).isEqualTo(post.modifiedAt)
+        }
+
+        @Test
+        fun notExist() {
+            val uuid = UUID.randomUUID()
+            doReturn(Optional.ofNullable(null)).`when`(mysqlPostJpaRepository).findById(safeAny(String::class.java))
+
+            // when & then
+            assertThrows(ResourceNotExistException::class.java) {
+                sut.findBy(uuid)
+            }
+        }
+    }
+
+    @Nested
+    inner class save {
+
+        @Test
+        fun normalCase() {
+            // given
+            val post = PostMother.generate()
+
+            // when
+            sut.save(post)
+
+            // then
+            verify(mysqlPostJpaRepository, times(1)).save(capture(captor))
+            val mysqlPostToSave = captor.value
+
+            assertThat(mysqlPostToSave.id).isEqualTo(post.id.toString())
+            assertThat(mysqlPostToSave.userId).isEqualTo(post.userId.toString())
+            assertThat(mysqlPostToSave.title).isEqualTo(post.title.name)
+            assertThat(mysqlPostToSave.content1Title).isEqualTo(post.content1.title)
+            assertThat(mysqlPostToSave.content1Description).isEqualTo(post.content1.description)
+            assertThat(mysqlPostToSave.content2Title).isEqualTo(post.content2.title)
+            assertThat(mysqlPostToSave.content2Description).isEqualTo(post.content2.description)
+            assertThat(mysqlPostToSave.createdAt).isEqualTo(post.createdAt)
+            assertThat(mysqlPostToSave.modifiedAt).isEqualTo(post.modifiedAt)
+        }
+    }
+
+    fun <T : Any> safeEq(value: T): T = Mockito.eq(value) ?: value
+    fun <T> safeAny(type: Class<T>): T = any<T>(type)
+    fun <T> capture(argumentCaptor: ArgumentCaptor<T>): T = argumentCaptor.capture()
+}

--- a/core/src/test/kotlin/com/meansoup/whatisthebetter/application/post/GetPostAppServiceTest.kt
+++ b/core/src/test/kotlin/com/meansoup/whatisthebetter/application/post/GetPostAppServiceTest.kt
@@ -41,7 +41,7 @@ internal class GetPostAppServiceTest {
 
         // then
         assertThat(getPostDto.id).isEqualTo(postId.toString())
-        assertThat(getPostDto.ownerUsername).isEqualTo(post.owner.name.name)
+        assertThat(getPostDto.ownerUsername).isEqualTo(post.userId.toString())
         assertThat(getPostDto.title).isEqualTo(post.title.name)
         assertThat(getPostDto.content1Title).isEqualTo(post.content1.title)
         assertThat(getPostDto.content1Description).isEqualTo(post.content1.description)

--- a/core/src/test/kotlin/com/meansoup/whatisthebetter/domain/post/PostTest.kt
+++ b/core/src/test/kotlin/com/meansoup/whatisthebetter/domain/post/PostTest.kt
@@ -16,11 +16,11 @@ internal class PostTest {
         val target2 = ContentMother.generate()
 
         // when
-        val post = Post(owner, title, target1, target2)
+        val post = Post(owner.id, title, target1, target2)
 
         // then
         assertThat(post.id).isNotNull()
-        assertThat(post.owner).isEqualTo(owner)
+        assertThat(post.userId).isEqualTo(owner)
         assertThat(post.title).isEqualTo(title)
         assertThat(post.content1).isEqualTo(target1)
         assertThat(post.content2).isEqualTo(target2)


### PR DESCRIPTION
post repository 구현

post에서 user를 제외
- post가 개념적으로 user의 정보를 알고 있기 때문에 넣었었음.
- 그치만 post가 user를 찾아와서 entity가 만들어져야 할 필요는 없음. 도메인 관점에서 post는 post의 데이터 자체로 완성되기 때문에.
- 그래서 뺌. 필요한 경우 application layer에서 post에서 찾은 userId로 user를 찾으면 되지 않을까 싶음.

회사에서 최근 유사하지는 않지만 같이 고려할만한 케이스에서
- lazy loading으로 문제를 해결하는 방향으로 논의함.
- 그치만 나는 이런 경우가 lazy loading까지 적용해서 entity가 entity를 물고 약간 억지스럽게 aggregate이 되어야하는지에 대한 의문이 있음.